### PR TITLE
Modify history and archived resource filtering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - 'transnet/develop'
-  pull_request:
-    branches:
-      - 'transnet/develop'
+
+# TODO: Sync with David
+#  pull_request:
+#   branches:
+#      - 'transnet/develop'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ on:
       - 'transnet/develop'
 
 # TODO: Sync with David
-#  pull_request:
-#   branches:
-#      - 'transnet/develop'
+  pull_request:
+   branches:
+      - 'transnet/develop'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
 name: Publish Temp Docker Image
 
 on:

--- a/app/src/main/java/org/lfenergy/compas/scl/data/config/FeatureFlagService.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/config/FeatureFlagService.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.config;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResource.java
@@ -78,13 +78,14 @@ public class ArchiveResource implements ArchivingApi {
         }
         String locationId = archivedResourcesSearch.getLocation();
         String name = archivedResourcesSearch.getName();
+        String author = archivedResourcesSearch.getAuthor();
         String approver = archivedResourcesSearch.getApprover();
         String contentType = archivedResourcesSearch.getContentType();
         String type = archivedResourcesSearch.getType();
         String voltage = archivedResourcesSearch.getVoltage();
         OffsetDateTime from = archivedResourcesSearch.getFrom();
         OffsetDateTime to = archivedResourcesSearch.getTo();
-        return compasSclDataService.searchArchivedResources(locationId, name, approver, contentType, type, voltage, from, to);
+        return compasSclDataService.searchArchivedResources(locationId, name, author, approver, contentType, type, voltage, from, to);
     }
 
     private ArchivedResource mapToArchivedResource(IAbstractArchivedResourceMetaItem archivedResource) {

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResource.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import io.smallrye.mutiny.Uni;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivingApi.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivingApi.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import io.smallrye.common.annotation.Blocking;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsApi.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsApi.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations;
 
 import io.smallrye.common.annotation.Blocking;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsResource.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations;
 
 import io.smallrye.mutiny.Uni;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/ErrorResponseDto.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/ErrorResponseDto.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Location.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Location.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Locations.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Locations.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Pagination.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/locations/model/Pagination.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResource.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.scl;
 
 import io.smallrye.mutiny.Uni;

--- a/app/src/main/openapi/archiving-api.yaml
+++ b/app/src/main/openapi/archiving-api.yaml
@@ -710,6 +710,9 @@ components:
         name:
           type: string
           description: "Partially match allowed"
+        author:
+          type: string
+          description: "Partially match allowed"
         approver:
           type: string
           description: "Fulltext match which can be retrieved via extra endpoint"

--- a/app/src/main/openapi/archiving-api.yaml
+++ b/app/src/main/openapi/archiving-api.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
 openapi: 3.0.3
 info:
   title: CoMPAS SCL Data Archiving API

--- a/app/src/main/openapi/data-resource-mockup.png.license
+++ b/app/src/main/openapi/data-resource-mockup.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+
+SPDX-License-Identifier: Apache-2.0

--- a/app/src/main/openapi/history-api.yaml
+++ b/app/src/main/openapi/history-api.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
 openapi: 3.0.3
 info:
   title: CoMPAS SCL Data Service History API

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResourceTest.java
@@ -116,7 +116,7 @@ class ArchiveResourceTest {
         IAbstractArchivedResourceMetaItem testData2 = new ArchivedSclResourceTestDataBuilder().setId(uuid2.toString()).setName(name).setVersion(version).build();
         IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of(testData1, testData2));
 
-        when(compasSclDataService.searchArchivedResources(null, name, null,null,null,null,null, null)).thenReturn(archivedResources);
+        when(compasSclDataService.searchArchivedResources(null, name, null,null,null,null,null,null, null)).thenReturn(archivedResources);
         Response response = given()
             .contentType(MediaType.APPLICATION_JSON)
             .body("{\"name\": \"Name\"}")
@@ -134,6 +134,37 @@ class ArchiveResourceTest {
         assertEquals(name, result.getResources().get(1).getName());
         assertEquals(version, result.getResources().get(1).getVersion());
     }
+
+
+    @Test
+    void searchArchivedResources_WhenCalledOnlyWithAuthor_ThenReturnsMatchingArchivedResources() {
+        UUID uuid = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        String name = "Name";
+        String version = "1.0.0";
+        String author1 = "John Doe";
+        String author2 = "John Smith";
+        IAbstractArchivedResourceMetaItem testData1 = new ArchivedSclResourceTestDataBuilder().setId(uuid.toString()).setName(name).setVersion(version).setAuthor(author1).build();
+        IAbstractArchivedResourceMetaItem testData2 = new ArchivedSclResourceTestDataBuilder().setId(uuid2.toString()).setName(name).setVersion(version).setAuthor(author2).build();
+        IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of(testData1, testData2));
+
+        when(compasSclDataService.searchArchivedResources(null, null, "John",null,null,null,null,null, null)).thenReturn(archivedResources);
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"John\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertEquals(uuid, UUID.fromString(result.getResources().get(0).getUuid()));
+        assertEquals(author1, result.getResources().get(0).getAuthor());
+        assertEquals(uuid2, UUID.fromString(result.getResources().get(1).getUuid()));
+        assertEquals(author2, result.getResources().get(1).getAuthor());
+    }
+
 
     @Test
     void retrieveArchivedResourceHistory_WhenCalledWithUuid_ThenReturnsMatchingArchivedResources() {

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchiveResourceTest.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import io.quarkus.test.InjectMock;
@@ -22,9 +25,10 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @QuarkusTest
 @TestHTTPEndpoint(ArchiveResource.class)
@@ -165,6 +169,168 @@ class ArchiveResourceTest {
         assertEquals(author2, result.getResources().get(1).getAuthor());
     }
 
+    @Test
+    void searchArchivedResources_WhenCalledWithNonExistingAuthor_ThenReturnsEmptyList() {
+        IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of());
+
+        when(compasSclDataService.searchArchivedResources(null, null, "John",null,null,null,null,null, null))
+                .thenReturn(archivedResources);
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"John\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertTrue(result.getResources().isEmpty());
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithBlankSpaceAuthorField_ThenReturnsEmptyList() {
+        IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of());
+
+        when(compasSclDataService.searchArchivedResources(null, null, "",null,null,null,null,null, null))
+                .thenReturn(archivedResources);
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertTrue(result.getResources().isEmpty());
+    }
+
+
+    @Test
+    void searchArchivedResources_WhenCalledWithAuthorAndNonMatchingApprover_ThenReturnsEmptyList() {
+        IArchivedResourcesMetaItem emptyResult = new ArchivedResourcesMetaItem(List.of());
+
+        when(compasSclDataService.searchArchivedResources(null, null, "John", "NonExistentApprover", null, null, null, null, null))
+                .thenReturn(emptyResult);
+
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"John\", \"approver\": \"NonExistentApprover\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertTrue(result.getResources().isEmpty());
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithAuthorAndNonMatchingLocation_ThenReturnsEmptyList() {
+        String locationId = "someLocationId";
+        IArchivedResourcesMetaItem emptyResult = new ArchivedResourcesMetaItem(List.of());
+
+        when(compasSclDataService.searchArchivedResources(locationId, null, "John", null, null, null, null, null, null))
+                .thenReturn(emptyResult);
+
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"John\", \"location\": \"" + locationId + "\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertTrue(result.getResources().isEmpty());
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithUuidAndAuthor_ThenAuthorIsIgnoredAndUuidTakesPrecedence() {
+        UUID uuid = UUID.randomUUID();
+        String name = "Name";
+        String version = "1.0.0";
+        IAbstractArchivedResourceMetaItem testData = new ArchivedSclResourceTestDataBuilder()
+                .setId(uuid.toString()).setName(name).setVersion(version).setAuthor("John Doe").build();
+        IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of(testData));
+
+        when(compasSclDataService.searchArchivedResources(uuid)).thenReturn(archivedResources);
+
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"uuid\": \"" + uuid + "\", \"author\": \"John Doe\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertEquals(1, result.getResources().size());
+        assertEquals(uuid, UUID.fromString(result.getResources().get(0).getUuid()));
+        verify(compasSclDataService, never()).searchArchivedResources(
+                any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithInvalidUuidFormat_ThenReturns500() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"uuid\": \"not-a-uuid\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithSingleQuoteInAuthor_ThenHandledSafely() {
+        String author = "O'Brien";
+        UUID uuid = UUID.randomUUID();
+        IAbstractArchivedResourceMetaItem testData = new ArchivedSclResourceTestDataBuilder()
+                .setId(uuid.toString()).setAuthor(author).build();
+        IArchivedResourcesMetaItem archivedResources = new ArchivedResourcesMetaItem(List.of(testData));
+
+        when(compasSclDataService.searchArchivedResources(null, null, author, null, null, null, null, null, null))
+                .thenReturn(archivedResources);
+
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"O'Brien\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertEquals(1, result.getResources().size());
+        assertEquals(author, result.getResources().get(0).getAuthor());
+    }
+
+    @Test
+    void searchArchivedResources_WhenCalledWithSqlInjectionInAuthor_ThenHandledSafely() {
+        String injectionAttempt = "'; DROP TABLE archived_resource; --";
+        IArchivedResourcesMetaItem emptyResult = new ArchivedResourcesMetaItem(List.of());
+
+        when(compasSclDataService.searchArchivedResources(null, null, injectionAttempt, null, null, null, null, null, null))
+                .thenReturn(emptyResult);
+
+        Response response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"'; DROP TABLE archived_resource; --\"}")
+                .when().post("/resources/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        ArchivedResources result = response.as(ArchivedResources.class);
+        assertTrue(result.getResources().isEmpty());
+    }
 
     @Test
     void retrieveArchivedResourceHistory_WhenCalledWithUuid_ThenReturnsMatchingArchivedResources() {

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedReferencedResourceTestDataBuilder.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedReferencedResourceTestDataBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import org.lfenergy.compas.scl.data.model.ArchivedReferencedResourceMetaItem;

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedResourceVersionTestDataBuilder.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedResourceVersionTestDataBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import org.lfenergy.compas.scl.data.model.*;

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedSclResourceTestDataBuilder.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/archive/ArchivedSclResourceTestDataBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.archive;
 
 import org.lfenergy.compas.scl.data.model.*;

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationResourceTestDataBuilder.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationResourceTestDataBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations;
 
 import org.lfenergy.compas.scl.data.model.ILocationMetaItem;

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/locations/LocationsResourceTest.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.locations;
 
 import io.quarkus.test.InjectMock;

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResourceTest.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.scl;
 
 import io.quarkus.test.InjectMock;
@@ -118,5 +121,60 @@ class HistoryResourceTest {
         assertNotNull(responseData);
         String expectedContent = "hello world";
         assertArrayEquals(expectedContent.getBytes(), responseData);
+    }
+
+    @Test
+    void searchForResources_WhenCalledWithAuthorFilterAndNoMatchFound_ThenReturnsEmptyResults() {
+        when(compasSclDataService.listHistory(null, null, "NonExistentAuthor", null, null, null))
+                .thenReturn(List.of());
+
+        var response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"NonExistentAuthor\"}")
+                .when().post("/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        var dataResourcesResult = response.as(DataResourcesResult.class);
+        assertNotNull(dataResourcesResult);
+        assertTrue(dataResourcesResult.getResults().isEmpty());
+    }
+
+    @Test
+    void searchForResources_WhenCalledWithAuthorAndLocationFilterAndNoMatchFound_ThenReturnsEmptyResults() {
+        when(compasSclDataService.listHistory(null, null, "John", "someLocation", null, null))
+                .thenReturn(List.of());
+
+        var response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"author\": \"John\", \"location\": \"someLocation\"}")
+                .when().post("/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        var dataResourcesResult = response.as(DataResourcesResult.class);
+        assertNotNull(dataResourcesResult);
+        assertTrue(dataResourcesResult.getResults().isEmpty());
+    }
+
+    @Test
+    void searchForResources_WhenCalledWithInvalidType_ThenReturnsEmptyResult() {
+        var response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"type\": \"INVALID_TYPE\"}")
+                .when().post("/search")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        var dataResourcesResult = response.as(DataResourcesResult.class);
+        assertNotNull(dataResourcesResult);
+        assertTrue(dataResourcesResult.getResults() == null || dataResourcesResult.getResults().isEmpty());
+        verify(compasSclDataService, never()).listHistory(any(), any(), any(), any(), any(), any());
     }
 }

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResourceTestdataBuilder.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/api/scl/HistoryResourceTestdataBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.rest.api.scl;
 
 import org.lfenergy.compas.scl.data.model.HistoryMetaItem;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
 version: '3.8'
 
 services:

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/AbstractArchivedResourceMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/AbstractArchivedResourceMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedReferencedResourceMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedReferencedResourceMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourceVersion.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourceVersion.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourcesHistoryMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourcesHistoryMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.util.List;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourcesMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedResourcesMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.util.List;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedSclResourceMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ArchivedSclResourceMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/HistoryMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/HistoryMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/LocationMetaItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/LocationMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 public class LocationMetaItem implements ILocationMetaItem {

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ResourceTagItem.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/model/ResourceTagItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 public class ResourceTagItem implements IResourceTagItem {

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
@@ -596,13 +596,13 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
         }
 
         if (author != null) {
-            sqlBuilder.append(" AND subquery.created_by = ?");
-            parameters.add(author);
+            sqlBuilder.append(" AND subquery.created_by ILIKE ? ");
+            parameters.add("%" + author + "%");
         }
 
         if (location != null) {
-            sqlBuilder.append(" AND subquery.location = ?");
-            parameters.add(location);
+            sqlBuilder.append(" AND l.id = ?");
+            parameters.add(UUID.fromString(location));
         }
 
         if (from != null) {
@@ -1282,7 +1282,7 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
     }
 
     @Override
-    public IArchivedResourcesMetaItem searchArchivedResource(String locationId, String name, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
+    public IArchivedResourcesMetaItem searchArchivedResource(String locationId, String name, String author,String approver,String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
         List<Object> parameters = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         sb.append("""
@@ -1346,10 +1346,15 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
             parameters.add("%"+name+"%");
             sb.append(" AND (rr.filename ILIKE ? OR sf.name ILIKE ?)");
         }
+        if (author != null && !author.isBlank()) {
+            parameters.add("%"+author+"%");
+            parameters.add("%"+author+"%");
+            sb.append(" AND (rr.author ILIKE ? OR sf.created_by ILIKE ?)");
+        }
         if (approver != null && !approver.isBlank()) {
-            parameters.add(approver);
-            parameters.add(approver);
-            sb.append(" AND (rr.approver = ? OR xml_data.hitem_who::varchar = ?)");
+            parameters.add("%"+approver+"%");
+            parameters.add("%"+approver+"%");
+            sb.append(" AND (rr.approver ILIKE ? OR xml_data.hitem_who::varchar ILIKE ?)");
         }
         if (contentType != null && !contentType.isBlank()) {
             parameters.add(contentType);

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
@@ -1282,7 +1282,7 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
     }
 
     @Override
-    public IArchivedResourcesMetaItem searchArchivedResource(String locationId, String name, String author,String approver,String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
+    public IArchivedResourcesMetaItem searchArchivedResource(String locationId, String name, String author, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
         List<Object> parameters = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         sb.append("""

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
@@ -590,7 +590,7 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
             parameters.add(type.toString());
         }
 
-        if (name != null) {
+        if (name != null && !name.isBlank()) {
             sqlBuilder.append(" AND subquery.name ILIKE ?");
             parameters.add("%" + name + "%");
         }

--- a/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
+++ b/repository-postgresql/src/main/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepository.java
@@ -595,7 +595,7 @@ public class CompasSclDataPostgreSQLRepository implements CompasSclDataRepositor
             parameters.add("%" + name + "%");
         }
 
-        if (author != null) {
+        if (author != null && !author.isBlank()) {
             sqlBuilder.append(" AND subquery.created_by ILIKE ? ");
             parameters.add("%" + author + "%");
         }

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_10__create_resource_tag.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_10__create_resource_tag.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Creating table to hold Resource Tag Data. The Resource Tag is identified by its ID.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_11__create_archived_resource_resource_tag.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_11__create_archived_resource_resource_tag.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Creating many-to-many reference table to hold references to Archived Resource Data and Resource Tag Data.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_12__scl_file_add_location_id.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_12__scl_file_add_location_id.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Add 'location_id' column to the scl_file table.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_13__create_location_resource_tag.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_13__create_location_resource_tag.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Creating many-to-many reference table to hold references to Location Data and Resource Tag Data.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_6__scl_file_add_is_deleted.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_6__scl_file_add_is_deleted.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 -- Adding the boolean field 'is_deleted' with default value false
 ALTER TABLE scl_file
     ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_7__create_location.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_7__create_location.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Creating table to hold Location Data. The Location is identified by its ID.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_8__create_referenced_resource.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_8__create_referenced_resource.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Create table to hold Referenced Resource Data. A Referenced Resource is identified by its ID.
 --

--- a/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_9__create_archived_resource.sql
+++ b/repository-postgresql/src/main/resources/org/lfenergy/compas/scl/data/repository/postgresql/db/migration/V1_9__create_archived_resource.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 --
 -- Creating table to hold Archived Resource Data. An Archived Resource is identified by its ID.
 --

--- a/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
+++ b/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
@@ -3,11 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.repository.postgresql;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.compas.scl.data.model.IArchivedResourcesMetaItem;
+import org.lfenergy.compas.scl.data.model.IHistoryMetaItem;
+import org.lfenergy.compas.scl.data.model.Version;
 import org.lfenergy.compas.scl.data.repository.AbstractCompasSclDataRepositoryTest;
 import org.lfenergy.compas.scl.data.repository.CompasSclDataRepository;
+import org.lfenergy.compas.scl.extensions.model.SclFileType;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @ExtendWith({MockitoExtension.class, PostgreSQLServerJUnitExtension.class})
@@ -22,6 +37,395 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
     @BeforeEach
     void beforeEach() {
         repository = new CompasSclDataPostgreSQLRepository(PostgreSQLServerJUnitExtension.getDataSource());
+    }
+
+    @AfterEach
+    void afterEach() throws SQLException {
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.createStatement()) {
+            stmt.execute("TRUNCATE TABLE scl_label CASCADE");
+            stmt.execute("TRUNCATE TABLE scl_file CASCADE");
+            stmt.execute("TRUNCATE TABLE location_resource_tag CASCADE");
+            stmt.execute("TRUNCATE TABLE location CASCADE");
+            stmt.execute("TRUNCATE TABLE archived_resource CASCADE");
+            stmt.execute("TRUNCATE TABLE archived_resource_resource_tag CASCADE");
+            stmt.execute("TRUNCATE TABLE resource_tag CASCADE");
+        }
+    }
+
+
+    @Test
+    public void listHistory_WhenSearchingByAuthorSubstringAndLocation_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID locationId1 = createLocation("LOC1", "Test Location 1", "Description");
+        UUID locationId2 = createLocation("LOC2", "Test Location 2", "Description");
+
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        UUID id3 = UUID.randomUUID();
+
+        String sclData = """
+                    <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                        <Header id="header">
+                            <Hitem version="1.0.0" what="Initial version"/>
+                        </Header>
+                    </SCL>
+                """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Smith", locationId1);
+        createSclFileWithLocation(id2, "File2", sclData, "Jane Smith", locationId2);
+        createSclFileWithLocation(id3, "File3", sclData, "Bob Jones", locationId1);
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "Smi",
+                locationId1.toString(),
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.size()),
+                () -> assertEquals(id1.toString(), result.get(0).getId()),
+                () -> assertEquals(locationId1.toString(), result.get(0).getLocation())
+        );
+    }
+
+    @Test
+    void listHistory_WhenNoMatchingItems_ShouldReturnEmptyList() {
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "NonExistentAuthor",
+                UUID.randomUUID().toString(),
+                null,
+                null
+        );
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void listHistory_WhenSearchingByAuthorOnly_ShouldReturnAllMatchingItems() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        UUID id3 = UUID.randomUUID();
+
+        String sclData = """
+                    <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                        <Header id="header">
+                            <Hitem version="1.0.0" what="Initial version"/>
+                        </Header>
+                    </SCL>
+                """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+        createSclFile(id2, "File2", sclData, "Max Doe");
+        createSclFile(id3, "File3", sclData, "Max Smith");
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "Ma",
+                null,
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(2, result.size()),
+                () -> assertEquals(id2.toString(), result.get(0).getId()),
+                () -> assertEquals(id3.toString(), result.get(1).getId())
+        );
+    }
+
+    @Test
+    void listHistory_WhenSearchingByLocationIdOnly_ShouldReturnAllMatchingItems() throws SQLException {
+        // Given
+        UUID locationId1 = createLocation("LOC1", "Test Location 1", "Description");
+        UUID locationId2 = createLocation("LOC2", "Test Location 2", "Description");
+
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        UUID id3 = UUID.randomUUID();
+
+        String sclData = """
+                    <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                        <Header id="header">
+                            <Hitem version="1.0.0" what="Initial version"/>
+                        </Header>
+                    </SCL>
+                """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId1);
+        createSclFileWithLocation(id2, "File2", sclData, "Max Doe", locationId2);
+        createSclFileWithLocation(id3, "File3", sclData, "Max Smith", locationId2);
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                locationId2.toString(),
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(2, result.size()),
+                () -> assertTrue(result.stream()
+                        .anyMatch(r -> r.getLocation().equals(locationId2.toString())))
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenSearchingByAuthorOnly_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId);
+        createSclFileWithLocation(id2, "File2", sclData, "Jane Smith", locationId);
+
+        Version version = new Version(1, 0, 0);
+        UUID archivedId1 = archiveSclFile(id1, locationId, version, "Approver1", "John Doe");
+        UUID archivedId2 = archiveSclFile(id2, locationId, version, "Approver2", "Jane Smith");
+
+        // When
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "Doe", null, null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.getResources().size()),
+                () -> assertTrue(result.getResources().stream()
+                        .anyMatch(r -> r.getAuthor().equals("John Doe")))
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenSearchingByApproverOnly_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "Author1", locationId);
+        createSclFileWithLocation(id2, "File2", sclData, "Author2", locationId);
+
+        Version version = new Version(1, 0, 0);
+        archiveSclFile(id1, locationId , version, "Admin User", "Author1");
+        archiveSclFile(id2, locationId, version, "Test User", "Author2");
+
+        // When
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, null, "Admin", null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.getResources().size()),
+                () -> assertTrue(result.getResources().stream()
+                        .anyMatch(r -> r.getApprover().equals("Admin User")))
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenSearchingByAuthorAndApprover_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        UUID id3 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Smith", locationId);
+        createSclFileWithLocation(id2, "File2", sclData, "Jane Doe", locationId);
+        createSclFileWithLocation(id3, "File3", sclData, "John Doe", locationId);
+
+        Version version = new Version(1, 0, 0);
+        archiveSclFile(id1, locationId, version, "Admin User", "John Smith");
+        archiveSclFile(id2, locationId, version, "Test User", "Jane Doe");
+        archiveSclFile(id3, locationId, version, "Admin User", "John Doe");
+
+        // When
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "Joh", "Adm", null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(2, result.getResources().size()),
+                () -> assertTrue(result.getResources().stream()
+                    .anyMatch(r -> r.getAuthor().equals("John Smith") || r.getAuthor().equals("John Doe"))),
+                () -> assertTrue(result.getResources().stream()
+                    .anyMatch(r -> r.getApprover().equals("Admin User")))
+        );
+    }
+
+
+    @Test
+    void searchArchivedResource_WhenSearchingByNonExistingAuthorAndApprover_ShouldReturnMatchingItems() {
+        // When
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "Joh", "Adm", null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    private UUID createLocation(String key, String name, String description) throws SQLException {
+        UUID locationId = UUID.randomUUID();
+        String sql = "INSERT INTO location (id, key, name, description) VALUES (?, ?, ?, ?)";
+
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(sql)) {
+            stmt.setObject(1, locationId);
+            stmt.setString(2, key);
+            stmt.setString(3, name);
+            stmt.setString(4, description);
+            stmt.executeUpdate();
+        }
+        return locationId;
+    }
+
+    private void createSclFileWithLocation(UUID id, String name, String sclData, String author, UUID locationId) throws SQLException {
+        String sql = """
+                INSERT INTO scl_file(id, major_version, minor_version, patch_version, type, name, created_by, scl_data, location_id, is_deleted)
+                VALUES (?, 1, 0, 0, 'SCD', ?, ?, ?, ?, false)
+                """;
+
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(sql)) {
+            stmt.setObject(1, id);
+            stmt.setString(2, name);
+            stmt.setString(3, author);
+            stmt.setString(4, sclData);
+            stmt.setObject(5, locationId);
+            stmt.executeUpdate();
+        }
+    }
+
+    private void createSclFile(UUID id, String name, String sclData, String author) throws SQLException {
+        String sql = """
+                INSERT INTO scl_file(id, major_version, minor_version, patch_version, type, name, created_by, scl_data, is_deleted)
+                VALUES (?, 1, 0, 0, 'SCD', ?, ?, ?, false)
+        """;
+
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(sql)) {
+            stmt.setObject(1, id);
+            stmt.setString(2, name);
+            stmt.setString(3, author);
+            stmt.setString(4, sclData);
+            stmt.executeUpdate();
+        }
+    }
+
+    private UUID archiveSclFile(UUID id, UUID locationId ,Version version, String approver, String author) throws SQLException {
+        UUID archivedId = UUID.randomUUID();
+        UUID referencedResourceId = UUID.randomUUID();
+
+        String insertReferencedResource = """
+        INSERT INTO referenced_resource (id, content_type, filename, author, approver, location_id, scl_file_id, scl_file_major_version, scl_file_minor_version, scl_file_patch_version)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(insertReferencedResource)) {
+            stmt.setObject(1, referencedResourceId);
+            stmt.setString(2, "application/xml");
+            stmt.setString(3, "archived_file.xml");
+            stmt.setString(4, author);
+            stmt.setString(5, approver);
+            stmt.setObject(6, locationId);
+            stmt.setObject(7, id);
+            stmt.setInt(8, version.getMajorVersion());
+            stmt.setInt(9, version.getMinorVersion());
+            stmt.setInt(10, version.getPatchVersion());
+            stmt.executeUpdate();
+        }
+
+        String insertArchivedResource = """
+        INSERT INTO archived_resource (id, archived_at, referenced_resource_id, referenced_resource_major_version, referenced_resource_minor_version, referenced_resource_patch_version)
+        VALUES (?, NOW(), ?, ?, ?, ?)
+        """;
+
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(insertArchivedResource)) {
+            stmt.setObject(1, archivedId);
+            stmt.setObject(2, referencedResourceId);
+            stmt.setInt(3, version.getMajorVersion());
+            stmt.setInt(4, version.getMinorVersion());
+            stmt.setInt(5, version.getPatchVersion());
+            stmt.executeUpdate();
+        }
+
+        UUID tagId = UUID.randomUUID();
+
+        String insertTag = "INSERT INTO resource_tag (id, key, value) VALUES (?, ?, ?)";
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(insertTag)) {
+            stmt.setObject(1, tagId);
+            stmt.setString(2, "key1");
+            stmt.setString(3, "value1");
+            stmt.executeUpdate();
+        }
+
+        String linkTag = "INSERT INTO archived_resource_resource_tag (archived_resource_id, resource_tag_id) VALUES (?, ?)";
+        try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
+             var stmt = connection.prepareStatement(linkTag)) {
+            stmt.setObject(1, archivedId);
+            stmt.setObject(2, tagId);
+            stmt.executeUpdate();
+        }
+
+        return archivedId;
     }
 
 }

--- a/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
+++ b/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
@@ -16,6 +16,7 @@ import org.lfenergy.compas.scl.extensions.model.SclFileType;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -192,6 +193,41 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
     }
 
     @Test
+    void listHistory_WhenSearchingByNonExistingLocationId_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location 1", "Description");
+        UUID nonExistingLocationId = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(UUID.randomUUID(), "File1", sclData, "John Doe", locationId);
+        createSclFileWithLocation(UUID.randomUUID(), "File2", sclData, "Max Doe", locationId);
+        createSclFileWithLocation(UUID.randomUUID(), "File3", sclData, "Max Smith", locationId);
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                nonExistingLocationId.toString(),
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(0, result.size())
+        );
+    }
+
+    @Test
     void searchArchivedResource_WhenSearchingByAuthorOnly_ShouldReturnMatchingItems() throws SQLException {
         // Given
         UUID locationId = createLocation("LOC1", "Test Location", "Description");
@@ -210,8 +246,8 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         createSclFileWithLocation(id2, "File2", sclData, "Jane Smith", locationId);
 
         Version version = new Version(1, 0, 0);
-        UUID archivedId1 = archiveSclFile(id1, locationId, version, "Approver1", "John Doe");
-        UUID archivedId2 = archiveSclFile(id2, locationId, version, "Approver2", "Jane Smith");
+        archiveSclFile(id1, locationId, version, "Approver1", "John Doe");
+        archiveSclFile(id2, locationId, version, "Approver2", "Jane Smith");
 
         // When
         IArchivedResourcesMetaItem result = repository.searchArchivedResource(
@@ -316,6 +352,262 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         assertAll(
                 () -> assertNotNull(result),
                 () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenAuthorDoesNotMatchAnyResource_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "Jane Smith", locationId);
+        archiveSclFile(id1, locationId, new Version(1, 0, 0), "Approver1", "Jane Smith");
+
+        // When
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "NonExistingAuthor", null, null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenAuthorMatchesButLocationDoesNot_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId1 = createLocation("LOC1", "Test Location 1", "Description");
+        UUID locationId2 = createLocation("LOC2", "Test Location 2", "Description");
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId1);
+        archiveSclFile(id1, locationId1, new Version(1, 0, 0), "Approver1", "John Doe");
+
+        // When - author matches a resource in locationId1, but search is restricted to locationId2
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                locationId2.toString(), null, "John", null, null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenAuthorMatchesButApproverDoesNot_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId);
+        archiveSclFile(id1, locationId, new Version(1, 0, 0), "Admin User", "John Doe");
+
+        // When - author matches but approver does not
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "John", "NonExistingApprover", null, null, null, null, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    @Test
+    void searchArchivedResource_WhenAuthorMatchesButFromDateIsInTheFuture_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId = createLocation("LOC1", "Test Location", "Description");
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId);
+        archiveSclFile(id1, locationId, new Version(1, 0, 0), "Approver1", "John Doe");
+
+        OffsetDateTime futureDate = OffsetDateTime.now().plusDays(1);
+
+        // When - author matches but archived_at is before the 'from' date
+        IArchivedResourcesMetaItem result = repository.searchArchivedResource(
+                null, null, "John", null, null, null, null, futureDate, null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.getResources().isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenAuthorMatchesButLocationDoesNot_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID locationId1 = createLocation("LOC1", "Test Location 1", "Description");
+        UUID locationId2 = createLocation("LOC2", "Test Location 2", "Description");
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithLocation(id1, "File1", sclData, "John Doe", locationId1);
+
+        // When - author exists in locationId1 but search is restricted to locationId2
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "John",
+                locationId2.toString(),
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenAuthorMatchesButFromDateIsInTheFuture_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        OffsetDateTime futureDate = OffsetDateTime.now().plusDays(1);
+
+        // When - author matches but creation_date is before the 'from' date
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "John",
+                null,
+                futureDate,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenAuthorIsWhitespaceOnly_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+        createSclFile(id2, "File2", sclData, "Jane Smith");
+
+        // When - whitespace-only author is not blank-checked in listHistory, so it queries
+        // created_by ILIKE '%   %', which won't match any of the inserted authors
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "   ",
+                null,
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenAuthorIsLowercase_ShouldReturnMatchingResult() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+        createSclFile(id2, "File2", sclData, "Jane Smith");
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                "john",
+                null,
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.size())
         );
     }
 

--- a/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
+++ b/repository-postgresql/src/test/java/org/lfenergy/compas/scl/data/repository/postgresql/CompasSclDataPostgreSQLRepositoryTest.java
@@ -48,6 +48,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
             stmt.execute("TRUNCATE TABLE scl_file CASCADE");
             stmt.execute("TRUNCATE TABLE location_resource_tag CASCADE");
             stmt.execute("TRUNCATE TABLE location CASCADE");
+            stmt.execute("TRUNCATE TABLE referenced_resource CASCADE");
             stmt.execute("TRUNCATE TABLE archived_resource CASCADE");
             stmt.execute("TRUNCATE TABLE archived_resource_resource_tag CASCADE");
             stmt.execute("TRUNCATE TABLE resource_tag CASCADE");
@@ -188,7 +189,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
                 () -> assertNotNull(result),
                 () -> assertEquals(2, result.size()),
                 () -> assertTrue(result.stream()
-                        .anyMatch(r -> r.getLocation().equals(locationId2.toString())))
+                        .allMatch(r -> r.getLocation().equals(locationId2.toString())))
         );
     }
 
@@ -258,8 +259,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         assertAll(
                 () -> assertNotNull(result),
                 () -> assertEquals(1, result.getResources().size()),
-                () -> assertTrue(result.getResources().stream()
-                        .anyMatch(r -> r.getAuthor().equals("John Doe")))
+                () -> assertEquals("John Doe", result.getResources().get(0).getAuthor())
         );
     }
 
@@ -294,8 +294,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         assertAll(
                 () -> assertNotNull(result),
                 () -> assertEquals(1, result.getResources().size()),
-                () -> assertTrue(result.getResources().stream()
-                        .anyMatch(r -> r.getApprover().equals("Admin User")))
+                () -> assertEquals("Admin User", result.getResources().get(0).getApprover())
         );
     }
 
@@ -334,9 +333,11 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
                 () -> assertNotNull(result),
                 () -> assertEquals(2, result.getResources().size()),
                 () -> assertTrue(result.getResources().stream()
-                    .anyMatch(r -> r.getAuthor().equals("John Smith") || r.getAuthor().equals("John Doe"))),
+                        .anyMatch(r -> r.getAuthor().equals("John Doe"))),
                 () -> assertTrue(result.getResources().stream()
-                    .anyMatch(r -> r.getApprover().equals("Admin User")))
+                        .anyMatch(r -> r.getAuthor().equals("John Smith"))),
+                () -> assertTrue(result.getResources().stream()
+                    .allMatch(r -> r.getApprover().equals("Admin User")))
         );
     }
 
@@ -543,7 +544,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
     }
 
     @Test
-    void listHistory_WhenAuthorIsWhitespaceOnly_ShouldReturnEmptyList() throws SQLException {
+    void listHistory_WhenAuthorIsBlank_ShouldIgnoreAuthorFilterAndReturnAllItems() throws SQLException {
         // Given
         UUID id1 = UUID.randomUUID();
         UUID id2 = UUID.randomUUID();
@@ -559,12 +560,11 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         createSclFile(id1, "File1", sclData, "John Doe");
         createSclFile(id2, "File2", sclData, "Jane Smith");
 
-        // When - whitespace-only author is not blank-checked in listHistory, so it queries
-        // created_by ILIKE '%   %', which won't match any of the inserted authors
+        // When - blank author is treated as no filter, so all records are returned
         List<IHistoryMetaItem> result = repository.listHistory(
                 SclFileType.SCD,
                 null,
-                "   ",
+                " ",
                 null,
                 null,
                 null
@@ -573,7 +573,7 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         // Then
         assertAll(
                 () -> assertNotNull(result),
-                () -> assertTrue(result.isEmpty())
+                () -> assertEquals(2, result.size())
         );
     }
 
@@ -611,6 +611,287 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
         );
     }
 
+    @Test
+    void listHistory_WhenSearchingByType_ShouldReturnOnlyMatchingTypeItems() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFileWithType(id1, "ScdFile", sclData, "Author1", SclFileType.SCD);
+        createSclFileWithType(id2, "SsdFile", sclData, "Author2", SclFileType.SSD);
+
+        // When
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.size()),
+                () -> assertEquals(id1.toString(), result.get(0).getId()),
+                () -> assertEquals(SclFileType.SCD.toString(), result.get(0).getType())
+        );
+    }
+
+    @Test
+    void listHistory_WhenSearchingByTypeThatHasNoFiles_ShouldReturnEmptyList() throws SQLException {
+        // Given - only SCD files exist
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "Author1");
+
+        // When - searching for SSD but only SCD exists
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SSD,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenFromDateIsInThePast_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        OffsetDateTime pastDate = OffsetDateTime.now().minusDays(1);
+
+        // When - file was created after the 'from' date
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                pastDate,
+                null
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.size()),
+                () -> assertEquals(id1.toString(), result.get(0).getId())
+        );
+    }
+
+    @Test
+    void listHistory_WhenToDateIsInTheFuture_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        OffsetDateTime futureDate = OffsetDateTime.now().plusDays(1);
+
+        // When - file was created before the 'to' date
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                null,
+                futureDate
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(1, result.size()),
+                () -> assertEquals(id1.toString(), result.get(0).getId())
+        );
+    }
+
+    @Test
+    void listHistory_WhenToDateIsInThePast_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        OffsetDateTime pastDate = OffsetDateTime.now().minusDays(1);
+
+        // When - file was created after the 'to' date
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                null,
+                pastDate
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenCreationDateIsWithinFromToRange_ShouldReturnMatchingItems() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+        createSclFile(id2, "File2", sclData, "Jane Smith");
+
+        OffsetDateTime from = OffsetDateTime.now().minusDays(1);
+        OffsetDateTime to = OffsetDateTime.now().plusDays(1);
+
+        // When - both files were created within the from-to range
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                from,
+                to
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertEquals(2, result.size())
+        );
+    }
+
+    @Test
+    void listHistory_WhenCreationDateIsOutsideFromToRange_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        // Range is entirely in the past (before the file was created)
+        OffsetDateTime from = OffsetDateTime.now().minusDays(5);
+        OffsetDateTime to = OffsetDateTime.now().minusDays(1);
+
+        // When - file creation date falls outside the from-to range
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                from,
+                to
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
+    @Test
+    void listHistory_WhenFromDateIsAfterToDate_ShouldReturnEmptyList() throws SQLException {
+        // Given
+        UUID id1 = UUID.randomUUID();
+
+        String sclData = """
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                <Header id="header">
+                    <Hitem version="1.0.0" what="Initial version"/>
+                </Header>
+            </SCL>
+        """;
+
+        createSclFile(id1, "File1", sclData, "John Doe");
+
+        // Invalid range: from is after to
+        OffsetDateTime from = OffsetDateTime.now().plusDays(1);
+        OffsetDateTime to = OffsetDateTime.now().minusDays(1);
+
+        // When - no record can satisfy creation_date >= from AND creation_date <= to when from > to
+        List<IHistoryMetaItem> result = repository.listHistory(
+                SclFileType.SCD,
+                null,
+                null,
+                null,
+                from,
+                to
+        );
+
+        // Then
+        assertAll(
+                () -> assertNotNull(result),
+                () -> assertTrue(result.isEmpty())
+        );
+    }
+
     private UUID createLocation(String key, String name, String description) throws SQLException {
         UUID locationId = UUID.randomUUID();
         String sql = "INSERT INTO location (id, key, name, description) VALUES (?, ?, ?, ?)";
@@ -644,17 +925,22 @@ class CompasSclDataPostgreSQLRepositoryTest extends AbstractCompasSclDataReposit
     }
 
     private void createSclFile(UUID id, String name, String sclData, String author) throws SQLException {
+        createSclFileWithType(id, name, sclData, author, SclFileType.SCD);
+    }
+
+    private void createSclFileWithType(UUID id, String name, String sclData, String author, SclFileType type) throws SQLException {
         String sql = """
                 INSERT INTO scl_file(id, major_version, minor_version, patch_version, type, name, created_by, scl_data, is_deleted)
-                VALUES (?, 1, 0, 0, 'SCD', ?, ?, ?, false)
+                VALUES (?, 1, 0, 0, ?, ?, ?, ?, false)
         """;
 
         try (var connection = PostgreSQLServerJUnitExtension.getDataSource().getConnection();
              var stmt = connection.prepareStatement(sql)) {
             stmt.setObject(1, id);
-            stmt.setString(2, name);
-            stmt.setString(3, author);
-            stmt.setString(4, sclData);
+            stmt.setString(2, type.toString());
+            stmt.setString(3, name);
+            stmt.setString(4, author);
+            stmt.setString(5, sclData);
             stmt.executeUpdate();
         }
     }

--- a/repository-postgresql/src/test/resources/scl_history_testdata.sql
+++ b/repository-postgresql/src/test/resources/scl_history_testdata.sql
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
 DELETE
 FROM scl_file;
 

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/IAbstractArchivedResourceMetaItem.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/IAbstractArchivedResourceMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourceVersion.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourceVersion.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.time.OffsetDateTime;

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourcesHistoryMetaItem.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourcesHistoryMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.util.List;

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourcesMetaItem.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/IArchivedResourcesMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 import java.util.List;

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/ILocationMetaItem.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/ILocationMetaItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 public interface ILocationMetaItem {

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/IResourceTagItem.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/IResourceTagItem.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.model;
 
 public interface IResourceTagItem {

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/repository/CompasSclDataRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/repository/CompasSclDataRepository.java
@@ -278,6 +278,7 @@ public interface CompasSclDataRepository {
      *
      * @param location The location of the archived resource
      * @param name The name of the archived resource
+     * @param author The author of the archived resource
      * @param approver The approver of the archived resource
      * @param contentType The content type of the resource
      * @param type The type of the resource
@@ -286,7 +287,7 @@ public interface CompasSclDataRepository {
      * @param to The end timestamp of archiving (including)
      * @return All archived entries matching the search criteria
      */
-    IArchivedResourcesMetaItem searchArchivedResource(String location, String name, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to);
+    IArchivedResourcesMetaItem searchArchivedResource(String location, String name, String author, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to);
 
     /**
      * Retrieve all archived resource history versions according to an archived resource id

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/LocationData.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/LocationData.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/LocationMetaData.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/LocationMetaData.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceData.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceData.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceMetaData.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceMetaData.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import java.util.List;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceTag.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/ResourceTag.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/dto/TypeEnum.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/dto/TypeEnum.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataArchivingEloServiceImpl.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataArchivingEloServiceImpl.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataArchivingServiceImpl.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataArchivingServiceImpl.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.service;
 
 import io.quarkus.arc.lookup.LookupUnlessProperty;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/CompasSclDataService.java
@@ -745,8 +745,8 @@ public class CompasSclDataService {
      * @return All archived entries matching the search criteria
      */
     @Transactional(SUPPORTS)
-    public IArchivedResourcesMetaItem searchArchivedResources(String locationId, String name, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
-        return repository.searchArchivedResource(locationId, name, approver, getSclFileType(contentType), type, voltage, from, to);
+    public IArchivedResourcesMetaItem searchArchivedResources(String locationId, String name, String author, String approver, String contentType, String type, String voltage, OffsetDateTime from, OffsetDateTime to) {
+        return repository.searchArchivedResource(locationId, name, author, approver, getSclFileType(contentType), type, voltage, from, to);
     }
 
     private String getSclFileType(String contentType) {

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/ICompasSclDataArchivingService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/ICompasSclDataArchivingService.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.service;
 
 import io.smallrye.mutiny.Uni;

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/IEloConnectorRestClient.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/IEloConnectorRestClient.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.service;
 
 import io.smallrye.mutiny.Uni;

--- a/service/src/test/java/org/lfenergy/compas/scl/data/service/CompasSclDataServiceTest.java
+++ b/service/src/test/java/org/lfenergy/compas/scl/data/service/CompasSclDataServiceTest.java
@@ -689,7 +689,7 @@ class CompasSclDataServiceTest {
 
         verify(compasSclDataRepository, times(1)).findLocationByUUID(locationId);
         verify(compasSclDataRepository, times(0)).unassignResourceFromLocation(locationId, resourceId);
-        verify(compasSclDataRepository, times(0)).searchArchivedResource(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(compasSclDataRepository, times(0)).searchArchivedResource(any(), any(), any(),any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -1020,19 +1020,19 @@ class CompasSclDataServiceTest {
         );
         IArchivedResourcesMetaItem archivedResources1 = new ArchivedResourcesMetaItem(List.of(archivedResourceVersion, archivedResourceVersion1));
 
-        when(compasSclDataRepository.searchArchivedResource("someLocation", null, "someApprover", null, null, null, null, null))
+        when(compasSclDataRepository.searchArchivedResource("someLocation", null, null,"someApprover", null, null, null, null, null))
             .thenReturn(archivedResources1);
 
-        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources("someLocation", null, "someApprover", null, null, null, null, null);
+        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources("someLocation", null, null,"someApprover", null, null, null, null, null);
 
         assertFalse(actualMetaItem.getResources().isEmpty());
-        verify(compasSclDataRepository, times(1)).searchArchivedResource("someLocation", null, "someApprover", null, null, null, null, null);
+        verify(compasSclDataRepository, times(1)).searchArchivedResource("someLocation", null, null,"someApprover", null, null, null, null, null);
     }
 
     @Test
     void searchArchivedResources_whenCalledWithWrongSclFileTypeParameter_ThenThrowsException() {
-        assertThrows(CompasSclDataServiceException.class, () -> compasSclDataService.searchArchivedResources("someLocation", null, "someApprover", "asdf", null, null, null, null));
-        verify(compasSclDataRepository, times(0)).searchArchivedResource("someLocation", null, "someApprover", "asdf", null, null, null, null);
+        assertThrows(CompasSclDataServiceException.class, () -> compasSclDataService.searchArchivedResources("someLocation", null, null,"someApprover", "asdf", null, null, null, null));
+        verify(compasSclDataRepository, times(0)).searchArchivedResource("someLocation", null, null,"someApprover", "asdf", null, null, null, null);
     }
 
     @Test
@@ -1055,13 +1055,42 @@ class CompasSclDataServiceTest {
         );
         IArchivedResourcesMetaItem archivedResources1 = new ArchivedResourcesMetaItem(List.of(archivedResourceVersion));
 
-        when(compasSclDataRepository.searchArchivedResource("someLocation", null, "someApprover", "IID", null, null, null, null))
+        when(compasSclDataRepository.searchArchivedResource("someLocation", null, null,"someApprover", "IID", null, null, null, null))
             .thenReturn(archivedResources1);
 
-        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources("someLocation", null, "someApprover", "IID", null, null, null, null);
+        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources("someLocation", null, null,"someApprover", "IID", null, null, null, null);
 
         assertFalse(actualMetaItem.getResources().isEmpty());
-        verify(compasSclDataRepository, times(1)).searchArchivedResource("someLocation", null, "someApprover", "IID", null, null, null, null);
+        verify(compasSclDataRepository, times(1)).searchArchivedResource("someLocation", null, null,"someApprover", "IID", null, null, null, null);
+    }
+
+    @Test
+    void searchArchivedResources_whenCalledWithAuthor_ThenResourcesAreReturned() {
+        UUID archivedResourceId = UUID.randomUUID();
+        IAbstractArchivedResourceMetaItem archivedResourceVersion = new ArchivedSclResourceMetaItem(
+                archivedResourceId.toString(),
+                "archivedResourceName",
+                "1.0.0",
+                "John Doe",
+                "someApprover",
+                "IID",
+                null,
+                "someLocation",
+                List.of(),
+                null,
+                OffsetDateTime.now(),
+                null,
+                null
+        );
+        IArchivedResourcesMetaItem archivedResources1 = new ArchivedResourcesMetaItem(List.of(archivedResourceVersion));
+
+        when(compasSclDataRepository.searchArchivedResource(null, null, "John",null, null, null, null, null, null))
+                .thenReturn(archivedResources1);
+
+        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources(null, null, "John",null, null, null, null, null, null);
+
+        assertFalse(actualMetaItem.getResources().isEmpty());
+        verify(compasSclDataRepository, times(1)).searchArchivedResource(null, null, "John",null, null, null, null, null, null);
     }
 
     private Element createLabelElement(String validLabel) {

--- a/service/src/test/java/org/lfenergy/compas/scl/data/service/CompasSclDataServiceTest.java
+++ b/service/src/test/java/org/lfenergy/compas/scl/data/service/CompasSclDataServiceTest.java
@@ -476,6 +476,33 @@ class CompasSclDataServiceTest {
     }
 
     @Test
+    void listHistory_WhenCalledWithAuthorAndNoMatchingResults_ThenReturnsEmptyList() {
+        SclFileType searchFileType = SclFileType.SCD;
+
+        when(compasSclDataRepository.listHistory(searchFileType, null, "NonExistentAuthor", null, null, null))
+            .thenReturn(emptyList());
+
+        List<IHistoryMetaItem> items = compasSclDataService.listHistory(searchFileType, null, "NonExistentAuthor", null, null, null);
+
+        verify(compasSclDataRepository).listHistory(searchFileType, null, "NonExistentAuthor", null, null, null);
+        assertTrue(items.isEmpty());
+    }
+
+    @Test
+    void listHistory_WhenCalledWithAuthorAndLocationAndNoMatchingResults_ThenReturnsEmptyList() {
+        SclFileType searchFileType = SclFileType.SCD;
+        String location = UUID.randomUUID().toString();
+
+        when(compasSclDataRepository.listHistory(searchFileType, null, "John", location, null, null))
+            .thenReturn(emptyList());
+
+        List<IHistoryMetaItem> items = compasSclDataService.listHistory(searchFileType, null, "John", location, null, null);
+
+        verify(compasSclDataRepository).listHistory(searchFileType, null, "John", location, null, null);
+        assertTrue(items.isEmpty());
+    }
+
+    @Test
     void listHistoryVersionsByUUID_WhenCalledWithId_ThenReturnHistoryItems() {
         UUID itemId = UUID.randomUUID();
         IHistoryMetaItem historyItem = new HistoryMetaItem(
@@ -1091,6 +1118,40 @@ class CompasSclDataServiceTest {
 
         assertFalse(actualMetaItem.getResources().isEmpty());
         verify(compasSclDataRepository, times(1)).searchArchivedResource(null, null, "John",null, null, null, null, null, null);
+    }
+
+    @Test
+    void searchArchivedResources_whenCalledWithAuthorAndNoMatchingResults_ThenReturnsEmptyList() {
+        IArchivedResourcesMetaItem emptyResult = new ArchivedResourcesMetaItem(emptyList());
+
+        when(compasSclDataRepository.searchArchivedResource(null, null, "NonExistentAuthor", null, null, null, null, null, null))
+            .thenReturn(emptyResult);
+
+        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources(null, null, "NonExistentAuthor", null, null, null, null, null, null);
+
+        assertTrue(actualMetaItem.getResources().isEmpty());
+        verify(compasSclDataRepository, times(1)).searchArchivedResource(null, null, "NonExistentAuthor", null, null, null, null, null, null);
+    }
+
+    @Test
+    void searchArchivedResources_whenCalledWithAuthorAndInvalidContentType_ThenThrowsExceptionAndRepositoryIsNotCalled() {
+        assertThrows(CompasSclDataServiceException.class,
+            () -> compasSclDataService.searchArchivedResources(null, null, "John", null, "INVALID_TYPE", null, null, null, null));
+
+        verify(compasSclDataRepository, never()).searchArchivedResource(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void searchArchivedResources_whenCalledWithAuthorAndApproverAndNoMatchingResults_ThenReturnsEmptyList() {
+        IArchivedResourcesMetaItem emptyResult = new ArchivedResourcesMetaItem(emptyList());
+
+        when(compasSclDataRepository.searchArchivedResource(null, null, "John", "NonExistentApprover", null, null, null, null, null))
+            .thenReturn(emptyResult);
+
+        IArchivedResourcesMetaItem actualMetaItem = compasSclDataService.searchArchivedResources(null, null, "John", "NonExistentApprover", null, null, null, null, null);
+
+        assertTrue(actualMetaItem.getResources().isEmpty());
+        verify(compasSclDataRepository, times(1)).searchArchivedResource(null, null, "John", "NonExistentApprover", null, null, null, null, null);
     }
 
     private Element createLabelElement(String validLabel) {


### PR DESCRIPTION
### Changes
- `CompasSclDataPostgreSQLRepository.listHistory()` - modified author filter to accept substring
- `CompasSclDataPostgreSQLRepository.listHistory()` - replaced `subquery.location` by `l.id` in an AND-clause
- `CompasSclDataPostgreSQLRepository`, `CompasSclDataService`, `ArchiveResource`  - added filter with author name substring
- `CompasSclDataPostgreSQLRepository.searchArchivedResource()` - modified name and approver filters to accept substrings
- added unit tests for all modifications mentioned above